### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ominis-search.yml
+++ b/.github/workflows/ominis-search.yml
@@ -1,5 +1,8 @@
 name: Ominis Search
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/search-username.yml
+++ b/.github/workflows/search-username.yml
@@ -22,6 +22,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   username-search:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/AnonCatalyst/Ominis-OSINT/security/code-scanning/4](https://github.com/AnonCatalyst/Ominis-OSINT/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/ominis-search.yml` at the workflow root (top-level, alongside `name` and `on`).  
Best minimal fix without changing functionality is:

- `contents: read` (recommended baseline; needed for checkout/read access).
- Optionally keep only this unless a later step proves it needs additional scopes.

In this file, insert the block immediately after `name:` (or after `on:`), so it applies to all jobs unless overridden. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict GitHub Actions workflow permissions to read-only repository contents to address code scanning alerts about missing explicit permissions.

CI:
- Add explicit `contents: read` permissions to the Ominis Search workflow.
- Add explicit `contents: read` permissions to the publish workflow.
- Add explicit `contents: read` permissions to the search-username workflow.