### PR TITLE
Dependabot/pip/zipp gte 3.23.1

### DIFF
--- a/.github/workflows/ominis-search.yml
+++ b/.github/workflows/ominis-search.yml
@@ -1,5 +1,8 @@
 name: Ominis Search
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/search-username.yml
+++ b/.github/workflows/search-username.yml
@@ -22,6 +22,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   username-search:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary by Sourcery

Restrict default repository permissions for GitHub Actions workflows by explicitly granting read-only access to contents.

CI:
- Add explicit read-only contents permissions to the omis-search workflow.
- Add explicit read-only contents permissions to the publish workflow.
- Add explicit read-only contents permissions to the search-username workflow.