### PR TITLE
docs: fix broken image paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 🚀 Happy OSINTing! 🕵️‍♂️
 
-<img src="src/img/kmc_20241009_145637.png" alt="Ominis Osint Project - screenshot" width="550" height="430"/>
+<img src="ominis_src/img/kmc_20241009_145637.png" alt="Ominis Osint Project - screenshot" width="550" height="430"/>
 
 ## Features
 
@@ -127,7 +127,7 @@ Ominis OSINT provides a wealth of targetable and actionable results, empowering 
 Ominis OSINT Tools delivers actionable insights that enable users to make informed decisions, mitigate risks, and capitalize on opportunities in a rapidly evolving digital landscape.
 
 
-![Watch the video](src/img/video.gif)
+![Watch the video](ominis_src/img/video.gif)
 
 ## Configuration
 


### PR DESCRIPTION
Both images in the README point at `src/img/`, but there is no `src/` directory in the repository — the assets live in `ominis_src/img/`. As a result neither image renders on the repo landing page.

| Line | Was | Now |
|---|---|---|
| 32 | `src/img/kmc_20241009_145637.png` | `ominis_src/img/kmc_20241009_145637.png` |
| 130 | `src/img/video.gif` | `ominis_src/img/video.gif` |

Verified both files exist at the corrected paths. README-only change.

## Summary by Sourcery

Correct the README image paths so both referenced assets display on the repository landing page.

Bug Fixes:
- Fix broken README image links so the project screenshot and video render from their actual repository locations.

Documentation:
- Update README image paths to reference assets under `ominis_src/img/`.